### PR TITLE
Add each-index and sum-index macros

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,7 +1,7 @@
 #+CAPTION: Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.
 [[http://www.repostatus.org/badges/latest/wip.svg]]
 
-| This is an *alpha* release.  All the code works and unit tests are expected to run perfectly, but the operations are not optimized and the API change. |
+| This is an *alpha* release.  All the code works and unit tests are expected to pass, but the operations are not optimized and the API may change. |
 
 
 A version of this library is available from [[https://www.quicklisp.org/beta/][quicklisp]].
@@ -140,7 +140,7 @@ The following functions all make a new array, taking the dimensions as input. Th
 | ones     | Filled with ones                                                 |
 | rand     | Filled with uniformly distrubuted random numbers between 0 and 1 |
 | randn    | Normally distributed with mean 0 and standard deviation 1        |
-| linspace | Evenly spaced numbers in given range [START STOP]                |
+| linspace | Evenly spaced numbers in given range                             |
 
 =generate= (and =generate*=) allow you to generate arrays using functions.
 #+BEGIN_SRC lisp
@@ -163,6 +163,18 @@ Depending on the last argument, the function will be called with the (row-major)
   (aops:each #'+ #(0 1 2) #(2 3 5)) ; => #(2 4 7)
 #+END_SRC
 
+=vectorize= is a macro which performs elementwise operations 
+
+#+BEGIN_SRC lisp
+  (defparameter *a* #(1 2 3 4))
+  (aops:vectorize (*a*) (* 2 *a*)) ; => #(2 4 6 8)
+
+  (defparameter b #(2 3 4 5))
+  (aops:vectorize (a b) (* a (sin b))) ; => #(0.9092974 0.28224 -2.2704074 -3.8356972)
+#+END_SRC
+There is also a version =vectorize*= which takes a type argument for the resulting
+array, and a version =vectorize!= which sets elements in a given array.
+
 The semantics of =margin= are more difficult to explain, so perhaps an example will be more useful.  Suppose that you want to calculate column sums in a matrix.  You could =permute= (transpose) the matrix, =split= its subarrays at rank one (so you get a vector for each row), and apply the function that calculates the sum.  =margin= automates that for you:
 #+BEGIN_SRC lisp
   (aops:margin (lambda (column)
@@ -177,6 +189,55 @@ Finally, =recycle= allows you to recycle arrays along inner and outer dimensions
 #+BEGIN_SRC lisp
   (aops:recycle #(2 3) :inner 2 :outer 4)
   ; => #3A(((2 2) (3 3)) ((2 2) (3 3)) ((2 2) (3 3)) ((2 2) (3 3)))
+#+END_SRC
+
+** Indexing operations
+
+=nested-loop= is a simple macro which iterates over a set of indices with a given range
+
+#+BEGIN_SRC lisp
+  (defparameter A #2A((1 2) (3 4)))
+
+  (aops:nested-loop (i j) (array-dimensions A)
+    (setf (aref A i j) (* 2 (aref A i j))))
+  A ; => #2A((2 4) (6 8))
+
+  (aops:nested-loop (i j) '(2 3)
+    (format t "(~a ~a) " i j)) ; => (0 0) (0 1) (0 2) (1 0) (1 1) (1 2) 
+#+END_SRC
+
+=sum-index= is a macro which uses a simple code walker to determine the dimension sizes,
+summing over the given index or indices
+
+#+BEGIN_SRC lisp
+  (defparameter A #2A((1 2) (3 4)))
+
+  ;; Trace
+  (aops:sum-index i (aref A i i)) ; => 5
+
+  ;; Sum array
+  (aops:sum-index (i j) (aref A i i)) ; => 10
+
+  ;; Sum array
+  (aops:sum-index i (row-major-aref A i)) ; => 10
+#+END_SRC
+The main use for =sum-index= is in combination with =each-index=
+
+=each-index= is a macro which creates an array and iterates over the elements.
+Like =sum-index= it is given one or more index symbols, 
+and uses a code walker to find array dimensions.
+
+#+BEGIN_SRC lisp
+  (defparameter A #2A((1 2) (3 4)))
+  (defparameter B #2A((5 6) (7 8)))
+
+  ;; Transpose
+  (aops:each-index (i j) (aref A j i)) ; => #2A((1 3) (2 4))
+
+  ;; Matrix-matrix multiply
+  (aops:each-index (i j)
+     (aops:sum-index k
+        (* (aref A i k) (aref B k j)))) ; => #2A((19 22) (43 50))
 #+END_SRC
 
 ** Scalars as 0-dimensional arrays
@@ -199,9 +260,6 @@ You can also stack compatible arrays along any axis:
   
 #+END_SRC
 
-** Shared structure
-
-*Rules for that aren't finalized yet, see the source.*  Suggestions are welcome.
 
 * To-do list
 ** benchmark and optimize walk-subscripts and walk-subscripts-list

--- a/array-operations.asd
+++ b/array-operations.asd
@@ -17,6 +17,7 @@
                (:file "displacement")
                (:file "transformations")
                (:file "reductions")
+               (:file "indexing")
                (:file "stack")))
 
 (asdf:defsystem #:array-operations-tests

--- a/src/foreach.lisp
+++ b/src/foreach.lisp
@@ -1,0 +1,34 @@
+(in-package #:array-operations)
+
+(defun walk-array-indices (expr)
+  "Walks an expression tree EXPR, finds AREF calls. 
+   Returns a list of (symbol, array, index).
+
+   Example: 
+     (walk-array-indices '(+ (aref a i) (* 2 (aref b j k))))
+   
+   -> ((I A . 0) (K B . 1) (J B . 0))
+    
+  "
+  (cond
+    ;; If EXPR is not a list, nothing to return
+    ((not (listp expr)) nil)
+
+    ;; If EXPR is an AREF
+    ((equalp (first expr) 'aref)
+     ;; Parse this AREF for indices
+     (let ((arr (second expr)))
+       (do ((ind 0 (1+ ind))
+            (symlist (cddr expr) (cdr symlist))
+            ;; Build list of index constraints (symbol, array, index)
+            (result nil (if (symbolp (first symlist))
+                            (cons (cons (first symlist) (cons arr ind)) result)
+                            result)))
+           ((not symlist) result))))
+    
+    ;; Otherwise, walk elements of the list
+    ;; join together the alist
+    (t (mapcan #'walk-array-indices expr))))
+
+(defmacro foreach (syms &key (sum nil) &body body)
+  

--- a/src/foreach.lisp
+++ b/src/foreach.lisp
@@ -1,13 +1,13 @@
 (in-package #:array-operations)
 
-(defun walk-array-indices (expr)
-  "Walks an expression tree EXPR, finds AREF calls. 
-   Returns a list of (symbol, array, index).
+(defun find-array-dimensions (expr)
+  "Walks an expression tree EXPR, finds AREF and ROW-MAJOR-AREF calls. 
+   Returns a list of (symbol, expr)
 
    Example: 
-     (walk-array-indices '(+ (aref a i) (* 2 (aref b j k))))
+     (find-array-dimensions '(+ (aref a i) (* 2 (aref b j k))))
    
-   -> ((I A . 0) (K B . 1) (J B . 0))
+   -> ((I ARRAY-DIMENSION A 0) (K ARRAY-DIMENSION B 1) (J ARRAY-DIMENSION B 0))
     
   "
   (cond
@@ -22,13 +22,27 @@
             (symlist (cddr expr) (cdr symlist))
             ;; Build list of index constraints (symbol, array, index)
             (result nil (if (symbolp (first symlist))
-                            (cons (cons (first symlist) (cons arr ind)) result)
+                            (cons (list (first symlist) 'array-dimension arr ind) result)
                             result)))
            ((not symlist) result))))
+
+    ;; If EXPR is ROW-MAJOR-AREF
+    ((equalp (first expr) 'row-major-aref)
+     (list (list (third expr) 'array-total-size (second expr))))
     
     ;; Otherwise, walk elements of the list
     ;; join together the alist
-    (t (mapcan #'walk-array-indices expr))))
+    (t (mapcan #'find-array-dimensions expr))))
 
-(defmacro foreach (syms &key (sum nil) &body body)
-  
+(defmacro foreach (syms &key (sum nil) ((:do body) nil))
+  (let* ((dim-exprs (find-array-dimensions body))
+         (syms (if (listp syms) syms
+                   (list syms)))) ; Ensure that syms is a list
+    (dolist (sym syms)
+      ;; Check that SYM is a symbol
+      (unless (symbolp sym) (error "Index must be a symbol ~S" sym))
+      
+      ;; Find an expression which sets the range of SYM
+      (let ((dim-expr (assoc sym dim-exprs)))
+        (unless dim-expr (error "Cannot determine range of index ~S" sym))
+        (format t "~a -> ~a~%" sym (rest dim-expr))))))

--- a/src/indexing.lisp
+++ b/src/indexing.lisp
@@ -95,7 +95,7 @@
               result)))))
       
 ;;;
-;;; Alternative form:
+;;; More lispy way to iterate over indices
 ;;;
 ;;; (each-index (i j) expr)
 ;;;
@@ -111,6 +111,32 @@
 ;;;
 
 (defmacro each-index (index &body body)
+  "Given one or more symbols INDEX, walks the BODY expression 
+   to determine the index ranges by looking for 
+   AREF and ROW-MAJOR-AREF calls.
+
+  Transpose of 2D array A
+
+    (each-index (i j) 
+      (aref A j i))
+
+  Diagonal of a square 2D array
+
+    (each-index i (aref A i i))
+
+  Turn a 2D array into an array of arrays
+
+    (each-index i
+      (each-index j
+        (aref A i j)))
+
+  Matrix-vector product:
+
+    (each-index i
+      (sum-index j
+        (* (aref A i j) (aref x j))))
+
+  "
   (let ((dim-exprs (find-array-dimensions body))
         (index (if (listp index) index
                    (list index))))  ; Ensure that INDEX is a list

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -78,6 +78,9 @@
    #:argmax
    #:argmin
    #:vectorize-reduce)
+  (:export ; indexing
+   #:each-index
+   #:sum-index)
   (:export ; stack
    #:copy-row-major-block
    #:stack-rows-copy

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -359,6 +359,56 @@
     (assert-equalp 2
                    (aops:vectorize-reduce #'max (a b) (abs (- a b))))))
 
+;;; indexing
+
+(deftest each-index (tests)
+  (let ((a #2A((1 2 3) (4 5 6)))
+        (b #2A((1 2) (3 4))))
+    
+    ;; Transpose
+    (assert-equalp
+        #2A((1 4) (2 5) (3 6))
+        (aops:each-index (i j) (aref a j i)))
+
+    ;; Diagonal
+    (assert-equalp
+        #(1 4)
+        (aops:each-index i (aref b i i)))
+
+    ;; Arrays of arrays
+    (assert-equalp
+        #( #(1 2 3) #(4 5 6) )
+        (aops:each-index i
+          (aops:each-index j
+            (aref A i j))))
+    
+    ;; Matrix-matrix multiply
+    (assert-equalp
+        #2A((9 12 15) (19 26 33))
+      (aops:each-index (i j)
+        (aops:sum-index k
+          (* (aref B i k) (aref A k j)))))))
+
+
+(deftest sum-index (tests)
+  (let ((A #2A((1 2) (3 4))))
+
+    ;; Sum all elements
+    (assert-equalp
+        10
+        (aops:sum-index i (row-major-aref A i)))
+
+    ;; Sum all elements using AREF
+    (assert-equalp
+        10
+        (aops:sum-index (i j) (aref A i j)))
+
+    ;; Trace of array
+    (assert-equalp
+        5
+        (aops:sum-index i (aref A i i)))))
+    
+
 ;;; stack
 
 (deftest stack-rows (tests)


### PR DESCRIPTION
Tensor notation operations, such as matrix multiplies, transpose, trace etc. Both use the code walker to find the array dimensions, and can be nested (though no sum-index outside each-index).

* `sum-index` sums over one or more indices

     `(sum-index i (row-major-aref A i))`

  or

     `(sum-index (i j) (aref A i j))`

  would both sum over all elements of a 2D array A

* `each-index` creates an array, then iterates over one or more index.

  Transpose of a matrix:

    `(each-index (i j) (aref A j i))`

  Diagonal of a square matrix

    `(each-index i (aref A i i))`

These can be nested, for example a matrix-matrix multiply

    (each-index (i j)
      (sum-index k
        (* (aref A i k) (aref B k j))))