### PR TITLE
A few fixes for the function "fill-in-dimensions"

### DIFF
--- a/src/displacement.lisp
+++ b/src/displacement.lisp
@@ -144,7 +144,7 @@ product equals size.  Also accepts other dimension specifications (integer,
 array)."
   (aetypecase dimensions
     ((integer 0) (assert (= size it)) (list it))
-    (array (assert (= size (rank it))) (dims it))
+    (array (assert (= size (size it))) (dims it))
     (list (let+ (((&flet missing? (dimension) (eq dimension t)))
                  missing
                  (product 1))

--- a/src/displacement.lisp
+++ b/src/displacement.lisp
@@ -165,7 +165,9 @@ array)."
                   (mapcar (lambda (dimension)
                             (if (missing? dimension) fraction dimension))
                           dimensions))
-                dimensions)))))
+                (progn
+                  (assert (= size product))
+                  dimensions))))))
 
 (defun reshape (array dimensions &optional (offset 0))
   "Reshape ARRAY using DIMENSIONS (which can also be dimension

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -240,6 +240,15 @@
       (assert-equalp #(7 9) (setf (aops:subvec b 3 5) #(7 9)))
       (assert-equalp #(0 1 2 7 9 5) b)
       (assert-condition error (setf (aops:subvec b 3 5) #(7))))
+    ;; fill-in-dimensions, a helper function to reshape
+    (assert-equalp '(2) (aops::fill-in-dimensions 2 2))
+    (assert-equalp '(2) (aops::fill-in-dimensions #(1 2) 2))
+    (assert-equalp '(5 4) (aops::fill-in-dimensions '(5 4) 20))
+    (assert-equalp '(5 4) (aops::fill-in-dimensions '(5 t) 20))
+    (assert-condition error (aops::fill-in-dimensions 5 7))
+    (assert-condition error (aops::fill-in-dimensions #(2 3) 7))
+    (assert-condition error (aops::fill-in-dimensions '(2 3) 7))
+    (assert-condition error (aops::fill-in-dimensions '(t t) 7))
     ;; reshape & variances
     (assert-equalp #2A((0 1 2) (3 4 5)) (aops:reshape a '(2 3)))
     (assert-equalp #2A((0 1 2 3 4 5)) (aops:reshape-row a))


### PR DESCRIPTION
Noticed two problems with `fill-in-dimensions` (a helper function to `reshape`, both in _displace.lisp_):

1. If an array was given for the dimensions argument, the size argument was incorrectly checked against the given array's rank.

2. When a list of dimensions was given, without any blanks (`t` values), it was not checked against the size argument, as the doc string implied.

This PR includes tests added to _tests.lisp_ for the `fill-in-dimensions` function.

Cheers.

p.s. I thinking of removing the dependencies on `let+`, a utility by the original author, also a frozen project now. Would you be interested in such a patch?