### PR TITLE
Remove :let-plus

### DIFF
--- a/array-operations.asd
+++ b/array-operations.asd
@@ -7,7 +7,6 @@
   :license "MIT"
   :depends-on (#:alexandria
                #:anaphora
-               #:let-plus
                #:optima)
   :pathname #P"src/"
   :components ((:file "package")

--- a/src/displacement.lisp
+++ b/src/displacement.lisp
@@ -85,7 +85,8 @@ semantics of SETF easy."
   target)
 
 (defun (setf sub) (value array &rest subscripts)
-  (let+ (((&values subarray atom?) (apply #'sub array subscripts)))
+  (multiple-value-bind (subarray atom?)
+      (apply #'sub array subscripts)
     (if atom?
         (setf (apply #'aref array subscripts) value)
         (copy-into subarray value))))

--- a/src/displacement.lisp
+++ b/src/displacement.lisp
@@ -39,7 +39,7 @@ displaced and share structure."
   "Return (values OFFSET REMAINING-DIMENSIONS) that can be used to displace a
 row-major subarray starting at SUBSCRIPTS in an array with the given
 DIMENSIONS.  NOT EXPORTED."
-  (let+ (rev-dimensions
+  (let* (rev-dimensions
          rev-subscripts
          (tail (do ((dimensions dimensions (cdr dimensions))
                     (subscripts subscripts (cdr subscripts)))
@@ -48,7 +48,7 @@ DIMENSIONS.  NOT EXPORTED."
                          "More subscripts than dimensions.")
                  (let ((s (car subscripts))
                        (d (car dimensions)))
-                   (declare (type fixnum d))
+                   (declare (typei fixnum d))
                    (assert (and (integerp s) (< -1 s d)) ()
                            "Invalid subscript.")
                    (push s rev-subscripts)

--- a/src/displacement.lisp
+++ b/src/displacement.lisp
@@ -158,7 +158,8 @@ array)."
                            (check-type dimension (integer 1))
                            (multf product dimension))))
             (if missing
-                (let+ (((&values fraction remainder) (floor size product)))
+                (multiple-value-bind (fraction remainder)
+                    (floor size product)
                   (assert (zerop remainder) ()
                           "Substitution does not result in an integer ~
                           dimension.")

--- a/src/displacement.lisp
+++ b/src/displacement.lisp
@@ -136,7 +136,6 @@ that element is not an array, the original ARRAY is returned as it is."
   (setf (subseq vector start end) value))
 
 ;;; reshaping
-
 (defun fill-in-dimensions (dimensions size)
   "If one of the dimensions is missing (indicated with T), replace it with a
 dimension so that the total product equals SIZE.  If that's not possible,
@@ -145,7 +144,7 @@ product equals size.  Also accepts other dimension specifications (integer,
 array)."
   (aetypecase dimensions
     ((integer 0) (assert (= size it)) (list it))
-    (array (assert (= size (rank it))) (dims it))
+    (array (assert (= size (size it))) (dims it))
     (list (let+ (((&flet missing? (dimension) (eq dimension t)))
                  missing
                  (product 1))
@@ -166,7 +165,9 @@ array)."
                   (mapcar (lambda (dimension)
                             (if (missing? dimension) fraction dimension))
                           dimensions))
-                dimensions)))))
+                (progn
+                  (assert (= size product))
+                  dimensions))))))
 
 (defun reshape (array dimensions &optional (offset 0))
   "Reshape ARRAY using DIMENSIONS (which can also be dimension

--- a/src/displacement.lisp
+++ b/src/displacement.lisp
@@ -48,7 +48,7 @@ DIMENSIONS.  NOT EXPORTED."
                          "More subscripts than dimensions.")
                  (let ((s (car subscripts))
                        (d (car dimensions)))
-                   (declare (typei fixnum d))
+                   (declare (type fixnum d))
                    (assert (and (integerp s) (< -1 s d)) ()
                            "Invalid subscript.")
                    (push s rev-subscripts)

--- a/src/displacement.lisp
+++ b/src/displacement.lisp
@@ -69,8 +69,8 @@ with all the other subscripts set to 0, dimensions inferred from the original.
 If no subscripts are given, the original array is returned.  Implemented by
 displacing, may share structure."
   (if subscripts
-      (let+ (((&values offset dimensions)
-              (sub-location% (array-dimensions array) subscripts)))
+      (multiple-value-bind (offset dimensions)
+          (sub-location% (array-dimensions array) subscripts)
         (if dimensions
             (displace array dimensions offset)
             (apply #'aref array subscripts)))

--- a/src/displacement.lisp
+++ b/src/displacement.lisp
@@ -145,30 +145,29 @@ array)."
   (aetypecase dimensions
     ((integer 0) (assert (= size it)) (list it))
     (array (assert (= size (size it))) (dims it))
-    (list (let+ (((&flet missing? (dimension) (eq dimension t)))
-                 missing
-                 (product 1))
-            (loop for dimension in dimensions
-                  do (if (missing? dimension)
-                         (progn
-                           (assert (not missing) ()
-                                   "More than one missing dimension.")
-                           (setf missing t))
-                         (progn
-                           (check-type dimension (integer 1))
-                           (multf product dimension))))
-            (if missing
-                (multiple-value-bind (fraction remainder)
-                    (floor size product)
-                  (assert (zerop remainder) ()
-                          "Substitution does not result in an integer ~
-                          dimension.")
-                  (mapcar (lambda (dimension)
-                            (if (missing? dimension) fraction dimension))
-                          dimensions))
-                (progn
-                  (assert (= size product))
-                  dimensions))))))
+    (list (flet ((missing? (dimension) (eq dimension t)))
+            (let ((missing)
+                  (product 1))
+              (loop for dimension in dimensions
+                    do (if (missing? dimension)
+                           (progn
+                             (assert (not missing) ()
+                                     "More than one missing dimension.")
+                             (setf missing t))
+                           (progn
+                             (check-type dimension (integer 1))
+                             (multf product dimension))))
+              (if missing
+                  (multiple-value-bind (fraction remainder)
+                      (floor size product)
+                    (assert (zerop remainder) ()
+                            "Substitution does not result in an integer ~ dimension.")
+                    (mapcar (lambda (dimension)
+                              (if (missing? dimension) fraction dimension))
+                            dimensions))
+                  (progn
+                    (assert (= size product))
+                    dimensions)))))))
 
 (defun reshape (array dimensions &optional (offset 0))
   "Reshape ARRAY using DIMENSIONS (which can also be dimension

--- a/src/general.lisp
+++ b/src/general.lisp
@@ -75,8 +75,7 @@ When DIMS is not defined for an object, it falls back to as-array, which may be 
     (assert (= (rank array) 2))
     (array-dimension array 0))
   (:method (array)
-    (let+ (((nrow &ign) (dims array)))
-      nrow)))
+    (dim array 0)))
 
 (defgeneric ncol (array)
   (:documentation "Number of columns.  Will signal an error if ARRAY is not a matrix.")

--- a/src/general.lisp
+++ b/src/general.lisp
@@ -41,11 +41,13 @@ When DIMS is not defined for an object, it falls back to as-array, which may be 
   (:method (array)
     (array-dimensions (as-array array))))
 
-(define-let+-expansion (&dims dimensions :value-var value-var
-                                         :body-var body-var)
-  "Dimensions of array-like object."
-  `(let+ ((,dimensions (dims ,value-var)))
-     ,@body-var))
+;; "let-plus" has been removed as a dependency of this library.
+;; This will be left commented out, should someone want to use it in the future.
+;(define-let+-expansion (&dims dimensions :value-var value-var
+;                                         :body-var body-var)
+;  "Dimensions of array-like object."
+;  `(let+ ((,dimensions (dims ,value-var)))
+;     ,@body-var))
 
 (defgeneric size (array)
   (:documentation "Return the total number of elements in array.")

--- a/src/general.lisp
+++ b/src/general.lisp
@@ -84,8 +84,7 @@ When DIMS is not defined for an object, it falls back to as-array, which may be 
     (assert (= (rank array) 2))
     (array-dimension array 1))
   (:method (array)
-    (let+ (((&ign ncol) (dims array)))
-      ncol)))
+    (dim array 1)))
 
 (deftype array-matrix ()
   "A rank-2 array."

--- a/src/general.lisp
+++ b/src/general.lisp
@@ -96,7 +96,7 @@ When DIMS is not defined for an object, it falls back to as-array, which may be 
 
 (defun square-matrix? (matrix)
   "Test if MATRIX has two dimensions and that they are equal."
-  (let+ (((&accessors-r/o dims) matrix))
+  (let ((dims (dims matrix)))
     (and (length= dims 2)
          (= (first dims) (second dims)))))
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -4,7 +4,6 @@
   (:use #:cl
         #:alexandria
         #:anaphora
-        #:let-plus
         #:optima)
   (:nicknames #:aops)
   (:shadow #:flatten)

--- a/src/stack.lisp
+++ b/src/stack.lisp
@@ -148,7 +148,7 @@ When applicable, compatibility of dimensions is checked, and the result is used 
          (sum-first
           (reduce #'+ arrays
                   :key (lambda (array)
-                         (let+ ((dimensions (array-dimensions array)))
+                         (let ((dimensions (array-dimensions array)))
                            (unless (eq array array-first)
                              (assert (equal dim-rest (cdr dimensions)) ()
                                      "Array ~A has incomplatible dimensions"

--- a/src/stack.lisp
+++ b/src/stack.lisp
@@ -131,12 +131,14 @@ When applicable, compatibility of dimensions is checked, and the result is used 
                                    objects))
              (nrow (aif nrow it 1)))
         (aprog1 (make-array (list nrow ncol) :element-type element-type)
-          (mapc (lambda+ ((start-col &rest dims) object)
-                  (if dims
-                      (stack-cols-copy object it element-type start-col)
-                      (loop for row below nrow
-                            with object = (coerce object element-type)
-                            do (setf (aref it row start-col) object))))
+          (mapc (lambda (start-cols-and-dims object)
+                  (destructuring-bind (start-col &rest dims)
+                      start-cols-and-dims
+                    (if dims
+                        (stack-cols-copy object it element-type start-col)
+                        (loop for row below nrow
+                              with object = (coerce object element-type)
+                              do (setf (aref it row start-col) object)))))
                 start-cols-and-dims objects))))))
 
 (defun stack-cols (&rest objects)

--- a/src/stack.lisp
+++ b/src/stack.lisp
@@ -42,32 +42,32 @@ How objects are used depends on their dimensions, queried by DIMS:
 - when the object has 2 dimensions, use it as a matrix.
 
 When applicable, compatibility of dimensions is checked, and the result is used to determine the number of columns.  When all objects have 0 dimensions, the result has one column."
-  (let+ (ncol
-         ((&flet check-ncol (dim)
-            (if ncol
-                (assert (= ncol dim))
-                (setf ncol dim))))
-         (nrow 0)
-         (start-rows-and-dims (mapcar
-                               (lambda (object)
-                                 (let* ((dims (dims object))
-                                        (increment (ematch dims
-                                                     (nil 1)
-                                                     ((list d0) (check-ncol d0)
-                                                      1)
-                                                     ((list d0 d1) (check-ncol d1)
-                                                      d0))))
-                                   (prog1 (cons nrow dims)
-                                     (incf nrow increment))))
-                               objects))
-         (ncol (aif ncol it 1)))
-    (aprog1 (make-array (list nrow ncol) :element-type element-type)
-      (mapc (lambda+ ((start-row &rest dims) object)
-              (if dims
-                  (stack-rows-copy object it element-type start-row)
-                  (fill (displace it ncol (* start-row ncol))
-                        (coerce object element-type))))
-            start-rows-and-dims objects))))
+  (let (ncol)
+    (flet ((check-ncol (dim)
+             (if ncol
+                 (assert (= ncol dim))
+                 (setf ncol dim))))
+      (let* ((nrow 0)
+             (start-rows-and-dims (mapcar
+                                   (lambda (object)
+                                     (let* ((dims (dims object))
+                                            (increment (ematch dims
+                                                         (nil 1)
+                                                         ((list d0) (check-ncol d0)
+                                                          1)
+                                                         ((list d0 d1) (check-ncol d1)
+                                                          d0))))
+                                       (prog1 (cons nrow dims)
+                                         (incf nrow increment))))
+                                   objects))
+             (ncol (aif ncol it 1)))
+        (aprog1 (make-array (list nrow ncol) :element-type element-type)
+          (mapc (lambda+ ((start-row &rest dims) object)
+                  (if dims
+                      (stack-rows-copy object it element-type start-row)
+                      (fill (displace it ncol (* start-row ncol))
+                            (coerce object element-type))))
+                start-rows-and-dims objects))))))
 
 (defun stack-rows (&rest objects)
   "Like STACK-ROWS*, with ELEMENT-TYPE T."

--- a/src/stack.lisp
+++ b/src/stack.lisp
@@ -109,33 +109,33 @@ How objects are used depends on their dimensions, queried by DIMS:
 - when the object has 2 dimensions, use it as a matrix.
 
 When applicable, compatibility of dimensions is checked, and the result is used to determine the number of rows.  When all objects have 0 dimensions, the result has one row."
-  (let+ (nrow
-         ((&flet check-nrow (dim)
-            (if nrow
-                (assert (= nrow dim))
-                (setf nrow dim))))
-         (ncol 0)
-         (start-cols-and-dims (mapcar
-                               (lambda (object)
-                                 (let* ((dims (dims object))
-                                        (increment (ematch dims
-                                                     (nil 1)
-                                                     ((list d0) (check-nrow d0)
-                                                      1)
-                                                     ((list d0 d1) (check-nrow d0)
-                                                      d1))))
-                                   (prog1 (cons ncol dims)
-                                     (incf ncol increment))))
-                               objects))
-         (nrow (aif nrow it 1)))
-    (aprog1 (make-array (list nrow ncol) :element-type element-type)
-      (mapc (lambda+ ((start-col &rest dims) object)
-              (if dims
-                  (stack-cols-copy object it element-type start-col)
-                  (loop for row below nrow
-                        with object = (coerce object element-type)
-                        do (setf (aref it row start-col) object))))
-            start-cols-and-dims objects))))
+  (let (nrow)
+    (flet ((check-nrow (dim)
+             (if nrow
+                 (assert (= nrow dim))
+                 (setf nrow dim))))
+      (let* ((ncol 0)
+             (start-cols-and-dims (mapcar
+                                   (lambda (object)
+                                     (let* ((dims (dims object))
+                                            (increment (ematch dims
+                                                         (nil 1)
+                                                         ((list d0) (check-nrow d0)
+                                                          1)
+                                                         ((list d0 d1) (check-nrow d0)
+                                                          d1))))
+                                       (prog1 (cons ncol dims)
+                                         (incf ncol increment))))
+                                   objects))
+             (nrow (aif nrow it 1)))
+        (aprog1 (make-array (list nrow ncol) :element-type element-type)
+          (mapc (lambda+ ((start-col &rest dims) object)
+                  (if dims
+                      (stack-cols-copy object it element-type start-col)
+                      (loop for row below nrow
+                            with object = (coerce object element-type)
+                            do (setf (aref it row start-col) object))))
+                start-cols-and-dims objects))))))
 
 (defun stack-cols (&rest objects)
   "Like STACK-COLS*, with ELEMENT-TYPE T."

--- a/src/stack.lisp
+++ b/src/stack.lisp
@@ -62,11 +62,13 @@ When applicable, compatibility of dimensions is checked, and the result is used 
                                    objects))
              (ncol (aif ncol it 1)))
         (aprog1 (make-array (list nrow ncol) :element-type element-type)
-          (mapc (lambda+ ((start-row &rest dims) object)
-                  (if dims
-                      (stack-rows-copy object it element-type start-row)
-                      (fill (displace it ncol (* start-row ncol))
-                            (coerce object element-type))))
+          (mapc (lambda (start-rows-and-dims object)
+                  (destructuring-bind (start-row &rest dims)
+                      start-rows-and-dims
+                    (if dims
+                        (stack-rows-copy object it element-type start-row)
+                        (fill (displace it ncol (* start-row ncol))
+                              (coerce object element-type)))))
                 start-rows-and-dims objects))))))
 
 (defun stack-rows (&rest objects)

--- a/src/stack.lisp
+++ b/src/stack.lisp
@@ -143,7 +143,7 @@ When applicable, compatibility of dimensions is checked, and the result is used 
 
 (defun stack*0 (element-type arrays)
   "Stack arrays along the 0 axis, returning an array with given ELEMENT-TYPE."
-  (let+ ((array-first (car arrays))
+  (let* ((array-first (car arrays))
          (dim-rest (cdr (array-dimensions array-first)))
          (sum-first
           (reduce #'+ arrays

--- a/src/transformations.lisp
+++ b/src/transformations.lisp
@@ -237,16 +237,16 @@ as rank 0 arrays, following the usual semantics."
   "Fills an array RESULT with the result of
    an array expression. All input and outputs have the same
    shape, and BODY is evaluated for each index
-   
+
    VARIABLES must be a list of symbols bound to arrays.
    Each array must have the same dimensions. These are
    checked at compile and run-time respectively.
-   
+
        (let ((a #2A((1 2) (3 4)))
              (b (make-array '(2 2))))
            (vectorize! b (a) (+ a 1)))
        -> #2A((2 3) (4 5))
-   
+
        (let ((a #(1 2 3))
              (b #(4 5 6)))
            (vectorize! b (a b) (+ a (* b 2))))
@@ -261,7 +261,7 @@ as rank 0 arrays, following the usual semantics."
         (result-tmp (gensym)) ; New symbol needed for result, in case the input RESULT is in VARIABLES
         (type (gensym)) ; Element type
         (indx (gensym)))  ; Index inside loop from 0 to size
-    
+
     ;; Create a new array
     `(let* ((,size (array-total-size ,(first variables)))
             (,result-tmp ,result)  ; result may be an expression. once-only
@@ -277,7 +277,7 @@ as rank 0 arrays, following the usual semantics."
        (if (not (equal (array-dimensions ,(first variables))
                        (array-dimensions ,result-tmp)))
            (error "~S and ~S have different dimensions" ',(first variables) ',result))
-       
+
        (dotimes (,indx ,size)
          ;; Locally redefine variables to be scalars at a given index
          (let ,(mapcar (lambda (var) (list var `(row-major-aref ,var ,indx))) variables)
@@ -289,15 +289,15 @@ as rank 0 arrays, following the usual semantics."
   "Makes a new array of type ELEMENT-TYPE, containing the result of
    an array expression. All input and outputs have the same
    shape, and BODY is evaluated for each index
-   
+
    VARIABLES must be a list of symbols bound to arrays.
    Each array must have the same dimensions. These are
    checked at compile and run-time respectively.
-   
+
        (let ((a #2A((1 2) (3 4))))
            (vectorize* t (a) (+ a 1)))
        -> #2A((2 3) (4 5))
-   
+
        (let ((a #(1 2 3))
              (b #(4 5 6)))
            (vectorize* t (a b) (+ a (* b 2))))
@@ -313,15 +313,15 @@ as rank 0 arrays, following the usual semantics."
     "Makes a new array of type ELEMENT-TYPE, containing the result of
    an array expression. All input and outputs have the same
    shape, and BODY is evaluated for each index
-   
+
    VARIABLES must be a list of symbols bound to arrays.
    Each array must have the same dimensions. These are
    checked at compile and run-time respectively.
-   
+
        (let ((a #2A((1 2) (3 4))))
            (vectorize (a) (+ a 1)))
        -> #2A((2 3) (4 5))
-   
+
        (let ((a #(1 2 3))
              (b #(4 5 6)))
            (vectorize (a b) (+ a (* b 2))))

--- a/src/transformations.lisp
+++ b/src/transformations.lisp
@@ -133,15 +133,15 @@ Array element type is preserved."
   (let ((rank (array-rank array)))
     (if (identity-permutation? permutation rank)
         array
-        (let+ ((dimensions (array-dimensions array))
-               ((&flet map-subscripts (subscripts-vector)
-                  (map 'list (curry #'aref subscripts-vector) permutation))))
-          (check-permutation permutation rank)
-          (aprog1 (make-array (map-subscripts (coerce dimensions 'vector))
-                              :element-type (array-element-type array))
-            (walk-subscripts (dimensions subscripts position)
-              (setf (apply #'aref it (map-subscripts subscripts))
-                    (row-major-aref array position))))))))
+        (let ((dimensions (array-dimensions array)))
+          (flet ((map-subscripts (subscripts-vector)
+                   (map 'list (curry #'aref subscripts-vector) permutation)))
+            (check-permutation permutation rank)
+            (aprog1 (make-array (map-subscripts (coerce dimensions 'vector))
+                                :element-type (array-element-type array))
+              (walk-subscripts (dimensions subscripts position)
+                (setf (apply #'aref it (map-subscripts subscripts))
+                      (row-major-aref array position)))))))))
 
 
 ;;; each

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -72,11 +72,11 @@ etc."
 
 (defmacro nested-loop (syms dimensions &body body)
   "Iterates over a multidimensional range of indices.
-   
+
    SYMS must be a list of symbols, with the first symbol
-   corresponding to the outermost loop. 
-   
-   DIMENSIONS will be evaluated, and must be a list of 
+   corresponding to the outermost loop.
+
+   DIMENSIONS will be evaluated, and must be a list of
    dimension sizes, of the same length as SYMS.
 
    Example:
@@ -93,7 +93,7 @@ etc."
   with some additional type and dimension checks.
   "
   (unless syms (return-from nested-loop `(progn ,@body))) ; No symbols
-  
+
   ;; Generate gensyms for dimension sizes
   (let* ((rank (length syms))
          (syms-rev (reverse syms)) ; Reverse, since starting with innermost

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -39,7 +39,7 @@ is modified."
   (check-type position symbol)
   (check-type subscripts symbol)
   (with-unique-names (rank last increment dimensions-var)
-    `(let+ ((,dimensions-var (ensure-dimensions ,dimensions))
+    `(let* ((,dimensions-var (ensure-dimensions ,dimensions))
             (,rank (length ,dimensions-var))
             (,dimensions-var (make-array ,rank
                                          :element-type 'fixnum
@@ -47,16 +47,16 @@ is modified."
             (,last (1- ,rank))
             (,subscripts (make-array ,rank
                                      :element-type 'fixnum
-                                     :initial-element 0))
-            ((&labels ,increment (index)
-               (unless (minusp index)
-                 (when (= (incf (aref ,subscripts index))
-                          (aref ,dimensions-var index))
-                   (setf (aref ,subscripts index) 0)
-                   (,increment (1- index)))))))
-       (dotimes (,position (product ,dimensions-var))
-         ,@body
-         (,increment ,last)))))
+                                     :initial-element 0)))
+       (labels ((,increment (index)
+         (unless (minusp index)
+           (when (= (incf (aref ,subscripts index))
+                    (aref ,dimensions-var index))
+             (setf (aref ,subscripts index) 0)
+             (,increment (1- index))))))
+         (dotimes (,position (product ,dimensions-var))
+           ,@body
+           (,increment ,last))))))
 
 (defmacro walk-subscripts-list ((dimensions subscripts
                                  &optional (position (gensym "POSITION")))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -1,7 +1,7 @@
 ;;; -*- Mode:Lisp; Syntax:ANSI-Common-Lisp; Coding:utf-8 -*-
 
 (cl:defpackage #:array-operations-tests
-  (:use #:cl #:alexandria #:anaphora #:clunit #:let-plus)
+  (:use #:cl #:alexandria #:anaphora #:clunit)
   (:export #:run))
 
 (cl:in-package #:array-operations-tests)

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -302,9 +302,9 @@
   (assert-equalp '(3 2 0 1 4) (aops:complete-permutation '(3 2) 5))
   (assert-equalp '(0 1 2 3) (aops:invert-permutation '(0 1 2 3)))
   (assert-equalp '(1 3 2 0) (aops:invert-permutation '(3 0 2 1)))
-  (let+ (((&flet assert-equalp-i2 (permutation)
-            (assert-equalp permutation
-                (aops:invert-permutation (aops:invert-permutation permutation))))))
+  (flet ((assert-equalp-i2 (permutation)
+           (assert-equalp permutation
+               (aops:invert-permutation (aops:invert-permutation permutation)))))
     (assert-equalp-i2 '(0 1 2 3))
     (assert-equalp-i2 '(3 0 2 1))))
 

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -286,14 +286,14 @@
 
 (defun permute% (subscripts-mapping array)
   "Helper function for testing permutation.  Permutes ARRAY using SUBSCRIPTS-MAPPING, should return the permuted arguments as a list."
-  (let+ ((dimensions (array-dimensions array))
-         ((&flet map% (subscripts)
-            (apply subscripts-mapping subscripts))))
-    (aprog1 (make-array (map% dimensions)
-                        :element-type (array-element-type array))
+  (let ((dimensions (array-dimensions array)))
+    (flet ((map% (subscripts)
+             (apply subscripts-mapping subscripts)))
+      (aprog1 (make-array (map% dimensions)
+                          :element-type (array-element-type array))
       (aops:walk-subscripts-list (dimensions subscripts)
         (setf (apply #'aref it (map% subscripts))
-              (apply #'aref array subscripts))))))
+              (apply #'aref array subscripts)))))))
 
 (deftest permutations (tests)
   (assert-equalp #*10110 (aops::permutation-flags '(0 3 2) 5))


### PR DESCRIPTION
This removes all dependencies on :let-plus (https://github.com/tpapp/let-plus), the original `array-operations` author's custom "destructuring let", which they've also archived and declared un-maintained. 

Cheers.

(edited a typo)