### PR TITLE
Move matrix related functions to new file "matrices.lisp"

### DIFF
--- a/src/generic.lisp
+++ b/src/generic.lisp
@@ -86,18 +86,3 @@ When DIMS is not defined for an object, it falls back to as-array, which may be 
     (array-dimension array 1))
   (:method (array)
     (dim array 1)))
-
-(deftype array-matrix ()
-  "A rank-2 array."
-  '(array * (* *)))
-
-(declaim (inline matrix? square-matrix?))
-(defun matrix? (matrix)
-  "Test if MATRIX has rank 2."
-  (length= (dims matrix) 2))
-
-(defun square-matrix? (matrix)
-  "Test if MATRIX has two dimensions and that they are equal."
-  (let ((dims (dims matrix)))
-    (and (length= dims 2)
-         (= (first dims) (second dims)))))

--- a/src/matrices.lisp
+++ b/src/matrices.lisp
@@ -1,0 +1,20 @@
+;;; -*- Mode:Lisp; Syntax:ANSI-Common-Lisp; Coding:utf-8 -*-
+
+(in-package #:array-operations)
+
+;;; representing matrices as 2D arrays
+
+(deftype array-matrix ()
+  "A rank-2 array."
+  '(array * (* *)))
+
+(declaim (inline matrix? square-matrix?))
+(defun matrix? (matrix)
+  "Test if MATRIX has rank 2."
+  (length= (dims matrix) 2))
+
+(defun square-matrix? (matrix)
+  "Test if MATRIX has two dimensions and that they are equal."
+  (let ((dims (dims matrix)))
+    (and (length= dims 2)
+         (= (first dims) (second dims)))))


### PR DESCRIPTION
Functions moved from "generic.lisp" to "matrices.lisp":

- `matrix?`
- `square-matrix?`

...and also:

- `(deftype array-matrix ...)`
- `(declaim (inline matrix? square-matrix?))`