### PR TITLE
Rename predicates

### DIFF
--- a/src/displacing.lisp
+++ b/src/displacing.lisp
@@ -80,7 +80,7 @@ displacing, may share structure."
   "Copy SOURCE into TARGET, for array arguments of compatible
 dimensions (checked).  Return TARGET, making the implementation of the
 semantics of SETF easy."
-  (assert (same-dimensions? target source))
+  (assert (same-dimensions-p target source))
   (replace (flatten target) (flatten source))
   target)
 

--- a/src/displacing.lisp
+++ b/src/displacing.lisp
@@ -147,11 +147,11 @@ array)."
     (etypecase it
       ((integer 0) (assert (= size it)) (list it))
       (array (assert (= size (size it))) (dims it))
-      (list (flet ((missing? (dimension) (eq dimension t)))
+      (list (flet ((missingp (dimension) (eq dimension t)))
               (let ((missing)
                     (product 1))
                 (loop for dimension in dimensions
-                      do (if (missing? dimension)
+                      do (if (missingp dimension)
                              (progn
                                (assert (not missing) ()
                                        "More than one missing dimension.")
@@ -165,7 +165,7 @@ array)."
                       (assert (zerop remainder) ()
                               "Substitution does not result in an integer ~ dimension.")
                       (mapcar (lambda (dimension)
-                                (if (missing? dimension) fraction dimension))
+                                (if (missingp dimension) fraction dimension))
                               dimensions))
                     (progn
                       (assert (= size product))

--- a/src/displacing.lisp
+++ b/src/displacing.lisp
@@ -85,9 +85,9 @@ semantics of SETF easy."
   target)
 
 (defun (setf sub) (value array &rest subscripts)
-  (multiple-value-bind (subarray atom?)
+  (multiple-value-bind (subarray atomp)
       (apply #'sub array subscripts)
-    (if atom?
+    (if atomp
         (setf (apply #'aref array subscripts) value)
         (copy-into subarray value))))
 

--- a/src/generic.lisp
+++ b/src/generic.lisp
@@ -86,18 +86,3 @@ When DIMS is not defined for an object, it falls back to as-array, which may be 
     (array-dimension array 1))
   (:method (array)
     (dim array 1)))
-
-(deftype array-matrix ()
-  "A rank-2 array."
-  '(array * (* *)))
-
-(declaim (inline matrix? square-matrix?))
-(defun matrix? (matrix)
-  "Test if MATRIX has rank 2."
-  (length= (dims matrix) 2))
-
-(defun square-matrix? (matrix)
-  "Test if MATRIX has two dimensions and that they are equal."
-  (let ((dims (dims matrix)))
-    (and (length= dims 2)
-         (= (first dims) (second dims)))))

--- a/src/matrices.lisp
+++ b/src/matrices.lisp
@@ -1,0 +1,20 @@
+;;; -*- Mode:Lisp; Syntax:ANSI-Common-Lisp; Coding:utf-8 -*-
+
+(in-package #:array-operations)
+
+;;; representing matrices as 2D arrays
+
+(deftype array-matrix ()
+  "A rank-2 array."
+  '(array * (* *)))
+
+(declaim (inline matrix? square-matrix?))
+(defun matrix? (matrix)
+  "Test if MATRIX has rank 2."
+  (length= (dims matrix) 2))
+
+(defun square-matrix? (matrix)
+  "Test if MATRIX has two dimensions and that they are equal."
+  (let ((dims (dims matrix)))
+    (and (length= dims 2)
+         (= (first dims) (second dims)))))

--- a/src/matrices.lisp
+++ b/src/matrices.lisp
@@ -8,12 +8,13 @@
   "A rank-2 array."
   '(array * (* *)))
 
-(declaim (inline matrix? square-matrix?))
-(defun matrix? (matrix)
+(declaim (inline matrixp square-matrix-p))
+
+(defun matrixp (matrix)
   "Test if MATRIX has rank 2."
   (length= (dims matrix) 2))
 
-(defun square-matrix? (matrix)
+(defun square-matrix-p (matrix)
   "Test if MATRIX has two dimensions and that they are equal."
   (let ((dims (dims matrix)))
     (and (length= dims 2)

--- a/src/matrices.lisp
+++ b/src/matrices.lisp
@@ -19,3 +19,7 @@
   (let ((dims (dims matrix)))
     (and (length= dims 2)
          (= (first dims) (second dims)))))
+
+;; Aliases for deprecated names 'matrix?' and 'square-matrix?'
+(setf (definition 'matrix?) #'matrixp)
+(setf (definition 'square-matrix?) #'square-matrix-p)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -39,6 +39,9 @@
    #:nrow
    #:ncol
    #:array-matrix
+   #:matrixp
+   #:square-matrix-p
+   ;; These next two are deprecated aliases for the previous two.
    #:matrix?
    #:square-matrix?)
   (:export ; displacement
@@ -64,7 +67,8 @@
    #:complement-permutation
    #:complete-permutation
    #:invert-permutation
-   #:identity-permutation?
+   #:identity-permutation-p
+   #:identity-permutation? ; deprecated alias for above
    #:permute
    #:each*
    #:each

--- a/src/transforming.lisp
+++ b/src/transforming.lisp
@@ -88,6 +88,9 @@ checked, ie it may not be a permutation."
       permutation)
      (= index rank))))
 
+;; Alias to deprecated name for identity-permutation-p
+(setf (fdefinition 'identity-permutation?) #'identity-permutation-p)
+
 (defun permute (permutation array)
   "Return ARRAY with the axes permuted by PERMUTATION, which is a sequence of
 indexes.  Specifically, an array A is transformed to B, where

--- a/src/transforming.lisp
+++ b/src/transforming.lisp
@@ -74,8 +74,8 @@ single element."
             result)
           'list))
 
-(defun identity-permutation? (permutation
-                              &optional (rank (length permutation)))
+(defun identity-permutation-p (permutation
+                               &optional (rank (length permutation)))
   "Test if PERMUTATION is the identity permutation, ie a sequence of
 consecutive integers starting at 0.  Note that permutation is otherwise not
 checked, ie it may not be a permutation."

--- a/src/transforming.lisp
+++ b/src/transforming.lisp
@@ -39,10 +39,10 @@ for invalid and repeated indices.  NOT EXPORTED."
     result))
 
 (defun check-permutation (permutation
-                          &optional (rank (length permutation) rank?))
+                          &optional (rank (length permutation) rank-supplied-p))
   "Check if PERMUTATION is a valid permutation (of the given RANK), and signal
 an error if necessary."
-  (when rank?
+  (when rank-supplied-p
     (assert (= rank (length permutation)) ()
             'permutation-incompatible-rank ))
   (assert (every #'plusp (permutation-flags permutation)) ()

--- a/src/transforming.lisp
+++ b/src/transforming.lisp
@@ -121,7 +121,7 @@ Array element type is preserved."
   "Apply function to the array arguments elementwise, and return the result as
 an array with the given ELEMENT-TYPE.  Arguments are checked for dimension
 compatibility."
-  (assert (apply #'same-dimensions? array other-arrays))
+  (assert (apply #'same-dimensions-p array other-arrays))
   (let ((result (make-array (array-dimensions array)
                             :element-type element-type)))
     (apply #'map-into (flatten result) function

--- a/src/transforming.lisp
+++ b/src/transforming.lisp
@@ -101,7 +101,7 @@ P is the permutation.
 
 Array element type is preserved."
   (let ((rank (array-rank array)))
-    (if (identity-permutation? permutation rank)
+    (if (identity-permutation-p permutation rank)
         array
         (let ((dimensions (array-dimensions array)))
           (flet ((map-subscripts (subscripts-vector)

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -10,7 +10,7 @@
 
 (define-modify-macro multf (&rest values) * "Multiply by the arguments")
 
-(defun same-dimensions? (array &rest arrays)
+(defun same-dimensions-p (array &rest arrays)
   "Test if arguments have the same dimensions.  NOT EXPORTED."
   (let ((dimensions (array-dimensions array)))
     (every (lambda (array)

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -15,9 +15,9 @@
 (defsuite indexing (tests))
 (defsuite stack (tests))
 
-(defun run (&optional interactive?)
+(defun run (&optional interactivep)
   "Run all the tests for array-operations."
-  (run-suite 'tests :use-debugger interactive?))
+  (run-suite 'tests :use-debugger interactivep))
 
 ;;; creation
 


### PR DESCRIPTION
To my eyes, at least, this codebase reads like the author is pretty new to common lisp--so I've started to clean up bits that seem unprofitably unconventional, non-idiomatic, or that just really bother me. :-)

In this PR I've renamed the predicates from using '?' (Clojure and Scheme style) to using 'p' or '-p', Common Lisp style.

_(This depends on the previous matrices related PR, but can be rebased if needed.)_
