### PR TITLE
clunit is abandoned but the fork clunit2 is not

### DIFF
--- a/array-operations.asd
+++ b/array-operations.asd
@@ -18,7 +18,7 @@
   :license "MIT"
   :depends-on (:array-operations       ; loads everything else
                :alexandria
-               :clunit)
+               :clunit2)
   :pathname "tests/"
   :components ((:file "tests"))
   :perform (test-op (o c) (uiop:symbol-call :array-operations/tests :run)))


### PR DESCRIPTION
I think the above line says it all.
Heres the quickdoc:
http://quickdocs.org/clunit2/