### PR TITLE
Update creating.lisp to prevent randn/randn*/randn! from failing occasionally due to (log 0.0)

### DIFF
--- a/src/creating.lisp
+++ b/src/creating.lisp
@@ -122,15 +122,15 @@ Returns ARRAY."
       ;; then two normally-distributed numbers are
       ;;  z0 = r * cos(2pi u2)
       ;;  z1 = r * sin(2pi u2)
-      (let* ((u1 (random 1.0))
-             (2piu2 (* 2 pi (random 1.0))) ; 2 * pi * u2
+      (let* ((u1 (+ (random 1.0d0) least-positive-double-float))
+             (2piu2 (* 2 pi (random 1.0d0))) ; 2 * pi * u2
              (r (sqrt (* -2 (log u1)))))
         (setf (row-major-aref array i) (coerce (* r (cos 2piu2)) element-type))
         (setf (row-major-aref array (1+ i)) (coerce (* r (sin 2piu2)) element-type))))
     ;; If size is odd then one extra random number is needed
     (if (not (zerop (logand size 1)))
-        (let* ((u1 (random 1.0))
-               (2piu2 (* 2 pi (random 1.0)))
+        (let* ((u1 (+ (random 1.0d0) least-positive-double-float))
+               (2piu2 (* 2 pi (random 1.0d0)))
                (r (sqrt (* -2 (log u1)))))
           (setf (row-major-aref array (1- size)) (coerce (* r (cos 2piu2)) element-type))))
     array))


### PR DESCRIPTION
According to spec `(random k)` can return values  0 <= x < k, so `(random 1.0)` occasionally returns 0.0 crashing the `log` function, so I propose to add least-positive-..-float to shift the values. Note that since (random 1.0) < 1.0, adding the least-positive.. cannot cause it to go over 1.0 which would cause a change of sign of the logarithm and complex value of sqrt. The random returning of zero is more pronounced for single floats which was used originally. Also since, according to spec,  `pi` is defined as a long-float, which on most implementations is the same as double-float, the value ends up as double or long float anyways (before the final conversion if requested), so I propose to do the calculations in double floats.